### PR TITLE
feat: scope release job to 'release' environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,7 @@ jobs:
   release:
     name: Trigger release
     runs-on: ubuntu-24.04
+    environment: release
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

Bind the release job to the `release` GitHub Environment so `WORKFLOW_USER_GH_TOKEN` is gated by a deployment branch policy (`main` only) instead of being a repo-wide secret.

The environment with its branch policy and an env-scoped copy of the secret has already been provisioned on this repo. After this PR merges, the env-scoped secret takes over and the repo-level secret can be removed in a follow-up.

The existing `Validate ref` guard already restricted execution to `main`; the environment rule enforces the same constraint at the secrets layer (defense in depth).

## Trigger compatibility

- `schedule` — runs against the default branch (`main`), satisfies the policy.
- `workflow_dispatch` — runs against the chosen branch; only `main` is allowed by the policy. The `Validate ref` guard already enforced this.

## Test plan

- [x] Manually dispatch the workflow against `main` — job runs to completion (or exits cleanly via the "no commits since last release" path)

<img width="1001" height="391" alt="image" src="https://github.com/user-attachments/assets/8eda20e2-d26c-4340-826b-aea47e928ce6" />

- [x] Manually dispatch against a non-main branch — job is blocked by environment protection (expected)

<img width="1211" height="675" alt="image" src="https://github.com/user-attachments/assets/fff1b99e-adbc-4566-98c5-28f4ab816bab" />
